### PR TITLE
feat: update source from pixi-build-backends repo to pixi monorepo

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -5,7 +5,7 @@ set CARGO_PROFILE_RELEASE_STRIP=symbols
 set CARGO_PROFILE_RELEASE_LTO=fat
 
 :: Navigate to the source
-cd py-pixi-build-backend
+cd pixi-build-backends\py-pixi-build-backend
 
 :: Avoid path length issues
 set "CARGO_HOME=C:\ch-%RANDOM%"

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -10,10 +10,10 @@ export OPENSSL_DIR=$PREFIX
 # Use native-tls on conda-forge
 export MATURIN_PEP517_ARGS="--no-default-features --features=native-tls"
 
-pushd py-pixi-build-backend
+pushd pixi-build-backends/py-pixi-build-backend
 
 # Run the maturin build via pip which works for direct and
 # cross-compiled builds.
 $PYTHON -m pip install . -vv
 
-cargo-bundle-licenses --format yaml --output ../THIRDPARTY.yml
+cargo-bundle-licenses --format yaml --output ../../THIRDPARTY.yml

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,15 +2,15 @@
 context:
   name: py-pixi-build-backend
   python_name: pixi_build_backend
-  version: "0.4.2"
+  version: "0.4.3"
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 source:
-  url: https://github.com/prefix-dev/pixi-build-backends/archive/refs/tags/py-pixi-build-backend-v${{ version }}.tar.gz
-  sha256: 761de53e89d3f05d90a2d902cc00fb935a2302a710bc5097b819abe2c0ce99c6
+  url: https://github.com/prefix-dev/pixi/archive/refs/tags/${{ name }}-v${{ version }}.tar.gz
+  sha256: f2354df78c210ec5deb5cfbe87cc685cb739efd45049a3a759ad7b145a4ff50c
 
 build:
   number: 0
@@ -44,6 +44,7 @@ requirements:
 
 tests:
   - python:
+      pip_check: false
       imports:
         - pixi_build_backend
       python_version:
@@ -65,7 +66,7 @@ tests:
           then: abi3audit
 
 about:
-  homepage: https://github.com/prefix-dev/pixi-build-backends
+  homepage: https://github.com/prefix-dev/pixi
   summary: Python bindings for pixi-build-backends
   description: |
     This package provides Python bindings for pixi-build-backends, enabling
@@ -73,7 +74,7 @@ about:
   license: BSD-3-Clause
   license_file: LICENSE
   documentation: https://prefix-dev.github.io/pixi-build-backends
-  repository: https://github.com/prefix-dev/pixi-build-backends
+  repository: https://github.com/prefix-dev/pixi
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
The pixi-build-backends code has moved from
https://github.com/prefix-dev/pixi-build-backends into the pixi monorepo at https://github.com/prefix-dev/pixi. Update the source URL accordingly. Per-backend tags (e.g. pixi-build-cmake-v0.3.9) will be created in the pixi repo, so the tag format stays the same.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
